### PR TITLE
fxremainder now an alias to fxrem, and importing (chicken fixnum)

### DIFF
--- a/srfi-143/srfi-143.scm
+++ b/srfi-143/srfi-143.scm
@@ -20,8 +20,8 @@
           fxfirst-set-bit fxbit-field
           fxbit-field-rotate fxbit-field-reverse)
 
-  (import (rename (only chicken
-                        fxmax fxmin fx= fx< fx> fx<= fx>= fx/ fxmod
+  (import (rename (only (chicken fixnum)
+                        fxmax fxmin fx= fx< fx> fx<= fx>= fx/ fxmod fxrem
                         fxshl fxshr fixnum-bits
                         most-positive-fixnum most-negative-fixnum)
 		  (fxmax chicken:fxmax)
@@ -32,7 +32,7 @@
 		  (fx<= chicken:fx<=)
 		  (fx>= chicken:fx>=)
 		  (fx/ fxquotient)
-		  (fxmod fxremainder)
+		  (fxrem fxremainder)
                   (fxshl fxarithmetic-shift-left)
                   (fxshr fxarithmetic-shift-right)
 		  (fixnum-bits fx-width)


### PR DESCRIPTION
For details see the following message and the thread it is part of:

https://srfi-email.schemers.org/srfi-143/msg/15569316/

also see:

https://github.com/diamond-lizard/srfi-143/issues/1